### PR TITLE
Modify makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ targets = $(objects:.md=.html) # target file (list)
 all: $(targets)
 
 %.html : %.md
-	pandoc -s --self-contained -f markdown -t html -c github_kn.css "$<" > "$@"
+	cd ./html && pandoc -s --self-contained -f markdown -t html -c ../github_kn.css "$(subst html/,,$<)" > "$(subst html/,,$@)"
 
 clean:
 	rm -f $(targets)

--- a/makefile
+++ b/makefile
@@ -1,7 +1,12 @@
 objects = $(wildcard ./html/*.md) # source file (list)
 targets = $(objects:.md=.html) # target file (list)
 
+.PHONY: all clean
+
 all: $(targets)
 
 %.html : %.md
 	pandoc -s --self-contained -f markdown -t html -c github_kn.css "$<" > "$@"
+
+clean:
+	rm -f $(targets)


### PR DESCRIPTION
変更点は2つ。

cleanサブコマンドを追加。
ビルドされたhtmlを簡単に消せるようになります。

相対パスを含むリンクが正しくコンパイルできない点を適当に修正。
htmlディレクトリへ移動してからpandocを実行するように変更。
合わせてコマンドに与えるパスも変更した。
場当たり的なので、ちゃんと修正したほうがいい。